### PR TITLE
Use clang 3.7, address and undefined behavior sanitizers, and libomp and libc++

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,138 +1,121 @@
-## Emacs, make this -*- mode: sh; -*-
-# start with r-devel, which already contains many dependencies for building LLVM and R-devel
 FROM rocker/r-devel:latest
 
 ## This handle reaches Carl and Dirk
 MAINTAINER "Carl Boettiger and Dirk Eddelbuettel" rocker-maintainers@eddelbuettel.com
 
+# RUN echo "deb http://ftp.debian.org/debian experimental main" > /etc/apt/sources.list.d/debian-experimental.list
+
 ## Remain current
-RUN apt-get update -qq
-RUN apt-get dist-upgrade -y
-
-# pull in build dependencies for llvm-toolchain-3.7
-# can't use debian clang because their build with automake doesn't work with sanitizers
 RUN apt-get update -qq \
-	&& apt-get install -t unstable -y --no-install-recommends \
-		cmake flex bison dejagnu tcl expect perl libtool chrpath texinfo sharutils libffi-dev lsb-release patchutils diffstat xz-utils python-dev libedit-dev \
-		swig python-sphinx ocaml-nox binutils-dev libjsoncpp-dev lcov procps help2man dh-ocaml zlib1g-dev
+	&& apt-get dist-upgrade -y
 
-## Must build clang with cmake in order to get sanitizers
-RUN apt-get install -t unstable -y cmake
+# can't use debian clang because their build doesn't work with sanitizers
+# but can use clang to build clang
+RUN apt-get update -qq \
+	&& apt-get install -t unstable -y \
+	clang-3.7 \
+      	libxml2-dev \
+	libssl-dev \
+	littler \
+	libcurl4-openssl-dev \
+	texlive-base \
+	fonts-inconsolata \
+	git \
+	libssh2-1-dev \
+	qpdf \
+	pandoc \
+    	pandoc-citeproc \
+	cmake automake
+
+#RUN apt-get build-dep clang-3.7
 
 ## Check out R-devel
 RUN cd /tmp \
-	&& svn co http://svn.r-project.org/R/trunk R-san 
+	&& svn co http://svn.r-project.org/R/trunk R-devel 
 
-RUN apt-get install -y git
+# perhaps prefer a branch here, not always head. Original is actually SVN.
+RUN cd /tmp
+#RUN git clone http://llvm.org/git/llvm.git
+#RUN git clone http://llvm.org/git/clang.git
+#RUN git clone http://llvm.org/git/compiler-rt.git
+#RUN git clone http://llvm.org/git/clang-tools-extra.git
+#RUN git clone http://llvm.org/git/libcxx.git
+#RUN git clone http://llvm.org/git/libcxxabi.git
+RUN svn co https://llvm.org/svn/llvm-project/llvm/tags/RELEASE_370/final llvm
+RUN svn co https://llvm.org/svn/llvm-project/cfe/tags/RELEASE_370/final clang
+RUN svn co https://llvm.org/svn/llvm-project/clang-tools-extra/tags/RELEASE_370/final clang-tools-extra
+RUN svn co https://llvm.org/svn/llvm-project/compiler-rt/tags/RELEASE_370/final compiler-rt
+RUN svn co https://llvm.org/svn/llvm-project/libcxx/tags/RELEASE_370/final libcxx
+RUN svn co https://llvm.org/svn/llvm-project/libcxxabi/tags/RELEASE_370/final libcxxabi
+RUN svn co http://llvm.org/svn/llvm-project/openmp/tags/RELEASE_370/final openmp
 
-## Check out LLVM 3.7.0 release
-RUN cd /tmp \
-	&& svn co https://llvm.org/svn/llvm-project/llvm/tags/RELEASE_370/final llvm \
-	&& svn co https://llvm.org/svn/llvm-project/cfe/tags/RELEASE_370/final clang \
-	&& svn co https://llvm.org/svn/llvm-project/clang-tools-extra/tags/RELEASE_370/final clang-tools-extra \
-	&& svn co https://llvm.org/svn/llvm-project/compiler-rt/tags/RELEASE_370/final compiler-rt \
-	&& svn co https://llvm.org/svn/llvm-project/libcxx/tags/RELEASE_370/final libcxx \
-	&& svn co https://llvm.org/svn/llvm-project/libcxxabi/tags/RELEASE_370/final libcxxabi \
-	&& mv clang llvm/tools \
-	&& mv compiler-rt llvm/projects \
-	&& mv clang-tools-extra llvm/tools/clang/tools \
-	&& mv libcxx llvm/projects \
-	&& mv libcxxabi llvm/projects
+RUN mv clang llvm/tools
+RUN mv compiler-rt llvm/projects
+RUN mv clang-tools-extra llvm/tools/clang/tools
+RUN mv libcxx llvm/projects
+RUN mv libcxxabi llvm/projects
+RUN mv openmp llvm/projects
 
-# build LLVM using gcc from debian unstable
-# debian builds of LLVM use autotools, and thus do not contain sanitizers
-RUN mkdir /tmp/llvm-build \
-	&& cd /tmp/llvm-build && cmake \
-	  -DCMAKE_BUILD_TYPE:STRING=Release \
-	  -DLLVM_TARGETS_TO_BUILD:STRING=X86 \
-	  ../llvm
-RUN cd /tmp \
-	&& make -j5 -C llvm-build && make -C llvm-build install && rm -rf llvm-build
+# RUN apt-get install -t unstable -y libclang-3.7-dev
 
-# Replicating a CRAN maintainer's environment
-# ENV ASAN_OPTIONS 'detect_leaks=0:detect_odr_violation=0'
+RUN mkdir llvm-build
+RUN cd llvm-build && \
+  cmake \
+  -DCMAKE_BUILD_TYPE:STRING=Release \
+  -DLLVM_TARGETS_TO_BUILD:STRING=host \
+  -DCMAKE_INSTALL_PREFIX=/usr/local \
+  -DCLANG_DEFAULT_OPENMP_RUNTIME:STRING=libomp \
+  ../llvm
 
-## Build and install according extending the standard 'recipe' I emailed/posted years ago
-# potential tweaks here:
-#	don't disable openmp (gcc definitely fails without this, not sure yet about clang versions)
-#	use clang's libc++ (which is compiled already), instead of libstdc++ (seems to be used by CRAN maintainers in some environments) but introduces a lot of linker and library path issues which are beyond me. Maybe this is sanitizer, not libc++ related...
-#       ***Try with and without address,undefined - or just undefined or address
-#	CRAN environment seems to use -fno-sanitize=float-divide-by-zero,vptr (i.e. not ignoring 'function') and not to have -fno-sanitize-recover       
-#	-O2 is used by CRAN - don't know whether this has implications for ASAN or UBSAN
-#	consider --as-cran check, may fail with LD_PRELOAD as it does with gcc
-
-# did drop gnu99 from CFLAGS
-# dropped pedantic to try to fix long long problem
-
+# TODO: consider using clang to build clang
 #  -DCMAKE_C_COMPILER=clang-3.7 \
-#  -DCMAKE_CXX_COMPILER=clang++-3.7 \
-RUN cd /tmp/R-san \
-	&& R_PAPERSIZE=letter \
-	   R_BATCHSAVE="--no-save --no-restore" \
-	   R_BROWSER=xdg-open \
-	   PAGER=/usr/bin/pager \
-	   PERL=/usr/bin/perl \
-	   R_UNZIPCMD=/usr/bin/unzip \
-	   R_ZIPCMD=/usr/bin/zip \
-	   R_PRINTCMD=/usr/bin/lpr \
-	   LIBnn=lib \
-	   AWK=/usr/bin/awk \
-	   CFLAGS="-pipe -Wall -g -mtune=native" \
-	   CXXFLAGS="-pipe -Wall -g -mtune=native" \
-	   FFLAGS="-pipe -Wall -g -mtune=native" \
-	   FCFLAGS="-pipe -Wall -g -mtune=native" \
-	   CC="clang-3.7 -fsanitize=address,undefined -fno-sanitize=float-divide-by-zero,function -fno-sanitize-recover=undefined,integer -fno-omit-frame-pointer" \
-	   CXX="clang-3.7 -stdlib=stdc++ -fsanitize=address,undefined -fno-sanitize=float-divide-by-zero,vptr,function -fno-sanitize-recover=undefined,integer -fno-omit-frame-pointer" \
-	   CXX1X="clang-3.7 -stdlib=stdc++ -fsanitize=address,undefined -fno-sanitize=float-divide-by-zero,vptr,function -fno-sanitize-recover=undefined,integer -fno-omit-frame-pointer" \
-	   FC="gfortran" \
-	   F77="gfortran" \
-	   ./configure --enable-R-shlib \
+#  -DCMAKE_CXX_COMPILER=clang-3.7 \
+
+# don't use SupC++, we're going to use c++abi from LLVM project.
+#  -DLIBCXX_CXX_ABI=libsupc++ \
+#  -DLIBCXX_LIBSUPCXX_INCLUDE_PATHS="/usr/include/c++/5/;/usr/include/c++/5/x86_64-linux-gnu/" \
+#  -DLLVM_TARGETS_TO_BUILD:STRING=X86 \
+RUN make -j5 -C llvm-build && make -C llvm-build install 
+
+# eventually clean, but for testing, leave the build tree for diagnosis.
+# RUN rm -rf llvm-build
+
+RUN ldconfig
+
+# use config.site to set the R build environment
+COPY config.site /tmp/R-devel/config.site
+RUN cd /tmp/R-devel \
+	&& ./configure \
 	       --without-blas \
 	       --without-lapack \
 	       --with-readline \
 	       --without-recommended-packages \
-	       --program-suffix=san \
-	       --disable-openmp \
-	&& make -j5 \
+	       --program-suffix=devsan \
+     	&& make -j5 \
 	&& make install \
 	&& make clean
 
 ## Set Renviron to get libs from base R install
 RUN echo "R_LIBS=\${R_LIBS-'/usr/local/lib/R/site-library:/usr/local/lib/R/library:/usr/lib/R/library'}" >> /usr/local/lib/R/etc/Renviron
 
-## it seems that R is building with the right environment without the following:
-## RUN mv Makefile.site /usr/local/lib/R/etc
-
-## RUN cat << EOF > /usr/lib/local/R/etc/Makevars.site # just move file instead
-
 ## Set default CRAN repo
 RUN echo 'options("repos"="https://cran.rstudio.com")' >> /usr/local/lib/R/etc/Rprofile.site
 
-## to also build littler against RD
-##   1)	 apt-get install git autotools-dev automake
-##   2)	 use CC from RD CMD config CC, ie same as R
-##   3)	 use PATH to include RD's bin, ie
-## ie 
-##   CC="clang-3.5 -fsanitize=undefined -fno-sanitize=float-divide-by-zero,vptr,function -fno-sanitize-recover=undefined,integer" \
-##   PATH="/usr/local/lib/R/bin/:$PATH" \
-##   ./bootstrap
+# R doesn't actually run at all without this (can be considered a test of whether the sanitizers were actually compiled in correctly!)
+ENV ASAN_OPTIONS 'detect_leaks=0:detect_odr_violation=0'
 
 ## Check out littler
 RUN cd /tmp \
 	&& git clone https://github.com/eddelbuettel/littler.git
 
-# todo move this to top
-RUN apt-get install -y automake
+# R must have been built as a shared library so littler can be built and link to it:
+#RUN cd /tmp/littler \
+#	&& CC="clang-3.7 -fsanitize=address,undefined -fno-sanitize=float-divide-by-zero,vptr,function -fno-sanitize-recover=undefined,integer" PATH="/usr/local/lib/R/bin/:$PATH" ./bootstrap \
+#	&& ./configure --prefix=/usr \
+#	&& make \
+#	&& make install \
+#	&& cp -vax examples/*.r /usr/local/bin 
 
-RUN cd /tmp/littler \
-	&& CC="clang-3.7 -fsanitize=address,undefined -fno-sanitize=float-divide-by-zero,function -fno-sanitize-recover=undefined,integer" PATH="/usr/local/lib/R/bin/:$PATH" ./bootstrap \
-	&& ./configure --prefix=/usr \
-	&& make \
-	&& make install \
-	&& cp -vax examples/*.r /usr/local/bin 
-
-#RUN cd /usr/local/bin \
-#	&& mv R Rdevelsan \
-#	&& mv Rscript Rscriptdevelsan \
-#	&& ln -s Rdevelsan RDS \
-#	&& ln -s Rscriptdevelsan RDSscript
+# default cmd installs stressful packages
+RUN Rscript -e "install.packages(c('stringi', 'Rcpp', 'devtools')); library(devtools)"
+# install_github('jackwasey/icd9')"

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,20 +27,12 @@ RUN apt-get update -qq \
     	pandoc-citeproc \
 	cmake automake
 
-#RUN apt-get build-dep clang-3.7
-
 ## Check out R-devel
 RUN cd /tmp \
 	&& svn co http://svn.r-project.org/R/trunk R-devel 
 
 # perhaps prefer a branch here, not always head. Original is actually SVN.
 RUN cd /tmp
-#RUN git clone http://llvm.org/git/llvm.git
-#RUN git clone http://llvm.org/git/clang.git
-#RUN git clone http://llvm.org/git/compiler-rt.git
-#RUN git clone http://llvm.org/git/clang-tools-extra.git
-#RUN git clone http://llvm.org/git/libcxx.git
-#RUN git clone http://llvm.org/git/libcxxabi.git
 RUN svn co https://llvm.org/svn/llvm-project/llvm/tags/RELEASE_370/final llvm
 RUN svn co https://llvm.org/svn/llvm-project/cfe/tags/RELEASE_370/final clang
 RUN svn co https://llvm.org/svn/llvm-project/clang-tools-extra/tags/RELEASE_370/final clang-tools-extra
@@ -117,5 +109,5 @@ RUN cd /tmp \
 #	&& cp -vax examples/*.r /usr/local/bin 
 
 # default cmd installs stressful packages
-RUN Rscript -e "install.packages(c('stringi', 'Rcpp', 'devtools')); library(devtools)"
+# RUN Rscript -e "install.packages(c('stringi', 'Rcpp', 'devtools')); library(devtools)"
 # install_github('jackwasey/icd9')"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 ## Emacs, make this -*- mode: sh; -*-
-
-## start with the Docker 'base R' Debian-based image
-FROM r-base:latest
+# start with r-devel, which already contains many dependencies for building LLVM and R-devel
+FROM rocker/r-devel:latest
 
 ## This handle reaches Carl and Dirk
 MAINTAINER "Carl Boettiger and Dirk Eddelbuettel" rocker-maintainers@eddelbuettel.com
@@ -10,66 +9,55 @@ MAINTAINER "Carl Boettiger and Dirk Eddelbuettel" rocker-maintainers@eddelbuette
 RUN apt-get update -qq \
 	&& apt-get dist-upgrade -y
 
-## From the Build-Depends of the Debian R package, plus subversion, and clang-3.5
-## 
-## Also add   git autotools-dev automake  so that we can build littler from source
-##
+# pull in build dependencies for llvm-toolchain-3.7
+# can't use debian clang because their build with automake doesn't work with sanitizers
 RUN apt-get update -qq \
 	&& apt-get install -t unstable -y --no-install-recommends \
-		automake \
-		autotools-dev \
-		bash-completion \
-		bison \
-		clang-3.5 \
-		debhelper \
-		default-jdk \
-		g++ \
-		gcc \
-		gfortran \
-		git \
-		groff-base \
-		libblas-dev \
-		libbz2-dev \
-		libcairo2-dev \
-		libcurl4-openssl-dev \
-		libjpeg-dev \
-		liblapack-dev \
-		liblzma-dev \
-		libncurses5-dev \
-		libpango1.0-dev \
-		libpcre3-dev \
-		libpng-dev \
-		libreadline-dev \
-		libtiff5-dev \
-		libx11-dev \
-		libxt-dev \
-		mpack \
-		subversion \
-		tcl8.5-dev \
-		texinfo \
-		texlive-base \
-		texlive-extra-utils \
-		texlive-fonts-extra \
-		texlive-fonts-recommended \
-		texlive-generic-recommended \
-		texlive-latex-base \
-		texlive-latex-extra \
-		texlive-latex-recommended \
-		tk8.5-dev \
-		valgrind \
-		x11proto-core-dev \
-		xauth \
-		xdg-utils \
-		xfonts-base \
-		xvfb \
-		zlib1g-dev 
+		cmake flex bison dejagnu tcl expect perl libtool chrpath texinfo sharutils libffi-dev lsb-release patchutils diffstat xz-utils python-dev libedit-dev \
+		swig python-sphinx ocaml-nox binutils-dev libjsoncpp-dev lcov procps help2man dh-ocaml zlib1g-dev
 
 ## Check out R-devel
 RUN cd /tmp \
-	&& svn co http://svn.r-project.org/R/trunk R-devel 
+	&& svn co http://svn.r-project.org/R/trunk R-san 
+
+RUN apt-get install -y git
+
+## Check out LLVM 3.7.0 release
+RUN cd /tmp \
+	&& svn co https://llvm.org/svn/llvm-project/llvm/tags/RELEASE_370/final llvm \
+	&& svn co https://llvm.org/svn/llvm-project/cfe/tags/RELEASE_370/final clang \
+	&& svn co https://llvm.org/svn/llvm-project/clang-tools-extra/tags/RELEASE_370/final clang-tools-extra \
+	&& svn co https://llvm.org/svn/llvm-project/compiler-rt/tags/RELEASE_370/final compiler-rt \
+	&& svn co https://llvm.org/svn/llvm-project/libcxx/tags/RELEASE_370/final libcxx \
+	&& svn co https://llvm.org/svn/llvm-project/libcxxabi/tags/RELEASE_370/final libcxxabi \
+	&& mv clang llvm/tools \
+	&& mv compiler-rt llvm/projects \
+	&& mv clang-tools-extra llvm/tools/clang/tools \
+	&& mv libcxx llvm/projects \
+	&& mv libcxxabi llvm/projects
+
+# build LLVM using gcc from debian unstable
+# debian builds of LLVM use autotools, and thus do not contain sanitizers
+RUN mkdir /tmp/llvm-build \
+	&& cd /tmp/llvm-build && cmake \
+	  -DCMAKE_BUILD_TYPE:STRING=Release \
+	  -DLLVM_TARGETS_TO_BUILD:STRING=X86 \
+	  ../llvm
+RUN cd /tmp \
+	&& make -j5 -C llvm-build && make -C llvm-build install && rm -rf llvm-build
 
 ## Build and install according extending the standard 'recipe' I emailed/posted years ago
-RUN cd /tmp/R-devel \
+# potential tweaks here:
+#	don't disable openmp (gcc definitely fails without this, not sure yet about clang versions)
+#	use clang's libc++ (which is compiled already), instead of libstdc++ (seems to be used by CRAN maintainers in some environments) but introduces a lot of linker and library path issues which are beyond me. Maybe this is sanitizer, not libc++ related...
+#       ***Try with and without address,undefined - or just undefined or address
+#	CRAN environment seems to use -fno-sanitize=float-divide-by-zero,vptr (i.e. not ignoring 'function') and not to have -fno-sanitize-recover       
+#	-O2 is used by CRAN - don't know whether this has implications for ASAN or UBSAN
+#	consider --as-cran check, may fail with LD_PRELOAD as it does with gcc
+
+# did drop gnu99 from CFLAGS
+# dropped pedantic to try to fix long long problem
+RUN cd /tmp/R-san \
 	&& R_PAPERSIZE=letter \
 	   R_BATCHSAVE="--no-save --no-restore" \
 	   R_BROWSER=xdg-open \
@@ -80,13 +68,13 @@ RUN cd /tmp/R-devel \
 	   R_PRINTCMD=/usr/bin/lpr \
 	   LIBnn=lib \
 	   AWK=/usr/bin/awk \
-	   CFLAGS="-pipe -std=gnu99 -Wall -pedantic -g" \
-	   CXXFLAGS="-pipe -Wall -pedantic -g" \
-	   FFLAGS="-pipe -Wall -pedantic -g" \
-	   FCFLAGS="-pipe -Wall -pedantic -g" \
-	   CC="clang-3.5 -fsanitize=undefined -fno-sanitize=float-divide-by-zero,vptr,function -fno-sanitize-recover" \
-	   CXX="clang++-3.5 -fsanitize=undefined -fno-sanitize=float-divide-by-zero,vptr,function -fno-sanitize-recover" \
-	   CXX1X="clang++-3.5 -fsanitize=undefined -fno-sanitize=float-divide-by-zero,vptr,function -fno-sanitize-recover" \
+	   CFLAGS="-pipe -Wall -g" \
+	   CXXFLAGS="-pipe -Wall -g" \
+	   FFLAGS="-pipe -Wall -g" \
+	   FCFLAGS="-pipe -Wall -g" \
+	   CC="clang-3.7 -fsanitize=address,undefined -fno-sanitize=float-divide-by-zero,vptr,function -fno-sanitize-recover=undefined,integer" \
+	   CXX="clang-3.7 -stdlib=stdc++ -fsanitize=address,undefined -fno-sanitize=float-divide-by-zero,vptr,function -fno-sanitize-recover=undefined,integer" \
+	   CXX1X="clang-3.7 -stdlib=stdc++ -fsanitize=address,undefined -fno-sanitize=float-divide-by-zero,vptr,function -fno-sanitize-recover=undefined,integer" \
 	   FC="gfortran" \
 	   F77="gfortran" \
 	   ./configure --enable-R-shlib \
@@ -94,7 +82,7 @@ RUN cd /tmp/R-devel \
 	       --without-lapack \
 	       --with-readline \
 	       --without-recommended-packages \
-	       --program-suffix=dev \
+	       --program-suffix=san \
 	       --disable-openmp \
 	&& make \
 	&& make install \
@@ -104,14 +92,14 @@ RUN cd /tmp/R-devel \
 RUN echo "R_LIBS=\${R_LIBS-'/usr/local/lib/R/site-library:/usr/local/lib/R/library:/usr/lib/R/library'}" >> /usr/local/lib/R/etc/Renviron
 
 ## Set default CRAN repo
-RUN echo 'options("repos"="http://cran.rstudio.com")' >> /usr/local/lib/R/etc/Rprofile.site
+RUN echo 'options("repos"="https://cran.rstudio.com")' >> /usr/local/lib/R/etc/Rprofile.site
 
 ## to also build littler against RD
 ##   1)	 apt-get install git autotools-dev automake
 ##   2)	 use CC from RD CMD config CC, ie same as R
 ##   3)	 use PATH to include RD's bin, ie
 ## ie 
-##   CC="clang-3.5 -fsanitize=undefined -fno-sanitize=float-divide-by-zero,vptr,function -fno-sanitize-recover" \
+##   CC="clang-3.5 -fsanitize=undefined -fno-sanitize=float-divide-by-zero,vptr,function -fno-sanitize-recover=undefined,integer" \
 ##   PATH="/usr/local/lib/R/bin/:$PATH" \
 ##   ./bootstrap
 
@@ -119,17 +107,18 @@ RUN echo 'options("repos"="http://cran.rstudio.com")' >> /usr/local/lib/R/etc/Rp
 RUN cd /tmp \
 	&& git clone https://github.com/eddelbuettel/littler.git
 
+RUN apt-get install -y automake
+
 RUN cd /tmp/littler \
-	&& CC="clang-3.5 -fsanitize=undefined -fno-sanitize=float-divide-by-zero,vptr,function -fno-sanitize-recover" PATH="/usr/local/lib/R/bin/:$PATH" ./bootstrap \
+	&& CC="clang-3.7 -fsanitize=address,undefined -fno-sanitize=float-divide-by-zero,vptr,function -fno-sanitize-recover=undefined,integer" PATH="/usr/local/lib/R/bin/:$PATH" ./bootstrap \
 	&& ./configure --prefix=/usr \
 	&& make \
 	&& make install \
 	&& cp -vax examples/*.r /usr/local/bin 
 
-RUN cd /usr/local/bin \
-	&& mv R Rdevel \
-	&& mv Rscript Rscriptdevel \
-	&& ln -s Rdevel RD \
-	&& ln -s Rscriptdevel RDscript
-
+#RUN cd /usr/local/bin \
+#	&& mv R Rdevelsan \
+#	&& mv Rscript Rscriptdevelsan \
+#	&& ln -s Rdevelsan RDS \
+#	&& ln -s Rscriptdevelsan RDSscript
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 ## R-devel SAN using Clang: R development binaries with Sanitizer support
 
+Adapted by Jack Wasey to reflect a certain CRAN maintainer's [environment](http://www.stats.ox.ac.uk/pub/bdr/memtests/clang-ASAN/README.txt) which appeared to show address violations in some vector operations in my [icd9](https://github.com/jackwasey/icd9) package.
+
 The [Writing R Extensions manual](http://cran.r-project.org/doc/manuals/r-devel/R-exts.html)
 details in [Section 4.3](http://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Checking-memory-access)
 how to check memory access.  Two sections are devoted to

--- a/config.site
+++ b/config.site
@@ -1,0 +1,36 @@
+# remember to RECONFIGURE before MAKE
+           CC="clang -fsanitize=address,undefined -fno-sanitize=float-divide-by-zero,vptr,function -fno-omit-frame-pointer" 
+
+# try -nostdinc -nostdlibinc to stop it puling in gcc crap every time.
+# -nodefaultlibs dropped - it can't seem to find pthread things even if I specify -lgcc etc etc (-lc++ -lc++abi -lm -lc -lgcc_s -lgcc )
+           CXX="clang++ -fsanitize=address,undefined -fno-sanitize=float-divide-by-zero,vptr,function -stdlib=libc++ -lc++abi -fno-omit-frame-pointer -I/usr/local/include/c++/v1 -I/usr/local/include -L/usr/local/lib/clang/3.7.0/lib/linux -L/usr/local/lib" 
+
+        # R figures out whether we need -std=c++11 itself, so don't need to add flag here (and it can be harmful?)
+           CXX1X="${CXX}"
+           CFLAGS="-pipe -Wall -pedantic -g -O2 -mtune=native" 
+           CXXFLAGS="-pipe -Wall -pedantic -g -O2 -mtune=native" 
+
+           FC="gfortran" 
+           F77="gfortran" 
+           FFLAGS="-pipe -pedantic -g -O2 -mtune=native" 
+           FCFLAGS="-pipe -pedantic -g -O2 -mtune=native" 
+
+           MAIN_LD=${CXX}
+# is this OPENMP_CFLAGS instead?
+           R_OPENMP_CFLAGS=-fopenmp 
+           R_LD_LIBRARY_PATH=/usr/local/lib
+
+# Debian happier this way:
+           LIBnn=lib 
+
+# random environment stuff, maybe important:
+	   R_PAPERSIZE=letter 
+           R_BATCHSAVE="--no-save --no-restore" 
+           R_BROWSER=xdg-open 
+           PAGER=/usr/bin/pager 
+           PERL=/usr/bin/perl 
+           R_UNZIPCMD=/usr/bin/unzip 
+           R_ZIPCMD=/usr/bin/zip 
+           R_PRINTCMD=/usr/bin/lpr 
+           AWK=/usr/bin/awk 
+


### PR DESCRIPTION
I'm a novice pull requester, so sorry if this is bulky, but after a a lot of trial and error, I succeeded in replicating the test environment used by BDR. I daren't change anything to tidy it up for fear of it failing. There are many differences to the previous rocker image, so it may warrant a whole new image. Notable differences are:
- LLVM 3.7 compiled from source, and using libomp instead of libgomp
- R-devel, compiled with both address and undefined behavior sanitizers, and linked to libc++

I couldn't for the life of me eliminate all the references to libstdc++. I just don't understand enough about how the linker paths work, and if I excluded libstdc++ things too aggressively, then there would be symbol errors for things like pthreads.

Relates to:
https://github.com/RcppCore/Rcpp/issues/354

and this:
https://github.com/jackwasey/icd9/issues/75
has more information on the BDR test environment.

Hopefully more skilled people can take this forward.
