### PR TITLE
Detect stack use after scope

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,8 +83,8 @@ RUN cd /tmp/R-devel \
 	   R_PRINTCMD=/usr/bin/lpr \
 	   LIBnn=lib \
 	   AWK=/usr/bin/awk \
-	   CC="clang-4.0 -fsanitize=address,undefined -fno-sanitize=float-divide-by-zero -fno-omit-frame-pointer" \
-	   CXX="clang++-4.0 -stdlib=libc++ -fsanitize=address,undefined -fno-sanitize=float-divide-by-zero -fno-omit-frame-pointer" \
+	   CC="clang-4.0 -fsanitize=address,undefined -fno-sanitize=float-divide-by-zero -fno-omit-frame-pointer -fsanitize-address-use-after-scope" \
+	   CXX="clang++-4.0 -stdlib=libc++ -fsanitize=address,undefined -fno-sanitize=float-divide-by-zero -fno-omit-frame-pointer -fsanitize-address-use-after-scope" \
 	   CFLAGS="-g -O3 -Wall -pedantic -mtune=native" \
 	   FFLAGS="-g -O2 -mtune=native" \
 	   FCFLAGS="-g -O2 -mtune=native" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update -qq \
 		bash-completion \
 		bison \
 		clang-4.0 \
+		llvm-4.0 \
 		libc++-dev \
 		libc++abi-dev \
 		debhelper \
@@ -66,8 +67,9 @@ RUN apt-get update -qq \
 		zlib1g-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
-## Check out R-devel
-RUN cd /tmp \
+## Add symlink and check out R-devel
+RUN ln -s $(which llvm-symbolizer-4.0) /usr/local/bin/llvm-symbolizer \
+	&& cd /tmp \
 	&& svn co https://svn.r-project.org/R/trunk R-devel 
 
 ## Build and install according extending the standard 'recipe' I emailed/posted years ago

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,10 @@ RUN apt-get update -qq \
 		libpcre3-dev \
 		libpng-dev \
 		libreadline-dev \
+		libssl-dev \
 		libtiff5-dev \
 		libx11-dev \
+		libxml2-dev \
 		libxt-dev \
 		mpack \
 		subversion \


### PR DESCRIPTION
Only this setting detects a dplyr problem that is particularly difficult to find in the source code, see the links in https://github.com/tidyverse/dplyr/pull/3098. The issue itself materializes only with very aggressive optimization settings with clang.

A simplified self-contained version of the problem can be found at https://stackoverflow.com/q/46233852/946850. I fond this particular switch `-fsanitize-address-use-after-scope` in https://stackoverflow.com/a/42342428/946850. Indeed, my simplified problem evades detection without `-fsanitize-address-use-after-scope`.

CC @hadley @lionel- @gaborcsardi.